### PR TITLE
nonce & ucacAddr as unique id updates

### DIFF
--- a/contracts/CreditProtocol.sol
+++ b/contracts/CreditProtocol.sol
@@ -35,7 +35,7 @@ contract CreditProtocol is Ownable {
     // Ethereum client
     bytes prefix = "\x19Ethereum Signed Message:\n32";
 
-    event IssueCredit(bytes32 indexed ucac, address indexed creditor, address indexed debtor, uint256 amount, bytes32 memo);
+    event IssueCredit(bytes32 indexed ucac, address indexed creditor, address indexed debtor, uint256 amount, uint256 nonce, bytes32 memo);
     event UcacCreation(bytes32 indexed ucac, address indexed contractAddr, bytes32 denomination);
 
     function CreditProtocol(address _tokenContract, uint256 _txPerGigaTokenPerHour, uint256 _tokensToOwnUcac) {
@@ -54,8 +54,8 @@ contract CreditProtocol is Ownable {
                         , bytes32 memo
                         ) public {
         require(creditor != debtor);
-
-        bytes32 hash = keccak256(prefix, keccak256(ucac, creditor, debtor, amount, getNonce(creditor, debtor)));
+        uint256 nonce = getNonce(creditor, debtor);
+        bytes32 hash = keccak256(prefix, keccak256(ucac, creditor, debtor, amount, nonce));
 
         // verifying signatures
         require(ecrecover(hash, uint8(sig1[2]), sig1[0], sig1[1]) == creditor);
@@ -72,7 +72,7 @@ contract CreditProtocol is Ownable {
 
         balances[ucac][creditor] = balances[ucac][creditor] + int256(amount);
         balances[ucac][debtor] = balances[ucac][debtor] - int256(amount);
-        IssueCredit(ucac, creditor, debtor, amount, memo);
+        IssueCredit(ucac, creditor, debtor, amount, nonce, memo);
         incrementNonce(creditor, debtor);
     }
 

--- a/contracts/CreditProtocol.sol
+++ b/contracts/CreditProtocol.sol
@@ -36,7 +36,7 @@ contract CreditProtocol is Ownable {
     bytes prefix = "\x19Ethereum Signed Message:\n32";
 
     event IssueCredit(address indexed ucac, address indexed creditor, address indexed debtor, uint256 amount, uint256 nonce, bytes32 memo);
-    event UcacCreation(address indexed contractAddr, bytes32 denomination);
+    event UcacCreation(address indexed ucac, bytes32 denomination);
 
     function CreditProtocol(address _tokenContract, uint256 _txPerGigaTokenPerHour, uint256 _tokensToOwnUcac) {
         token = CPToken(_tokenContract);

--- a/test/CreditProtocol.js
+++ b/test/CreditProtocol.js
@@ -11,8 +11,6 @@ const BasicUCAC = artifacts.require('./BasicUCAC.sol');
 
 const usd = web3.fromAscii("USD");
 const testMemo = web3.fromAscii("test1")
-const ucacId1 = web3.sha3("hi");
-const ucacId2 = web3.sha3("yo");
 const creationStake = web3.toBigNumber(web3.toWei(3500));
 const mintAmount = web3.toBigNumber(web3.toWei(20000));
 
@@ -91,18 +89,18 @@ contract('CreditProtocolTest', function([admin, p1, p2, ucacAddr]) {
                                       , creationStake
                                       , {from: p1}).should.be.fulfilled;
             // stakeTokens call rejected prior to initialization
-            await this.creditProtocol.stakeTokens(ucacId2, creationStake, {from: p1}).should.be.rejectedWith(h.EVMThrow);
-            await this.creditProtocol.createAndStakeUcac(ucacAddr, ucacId2, usd, creationStake, {from: p1}).should.be.fulfilled;
+            await this.creditProtocol.stakeTokens(ucacAddr, creationStake, {from: p1}).should.be.rejectedWith(h.EVMThrow);
+            await this.creditProtocol.createAndStakeUcac(ucacAddr, usd, creationStake, {from: p1}).should.be.fulfilled;
             await this.cpToken.approve( this.creditProtocol.address
                                       , postCreationStake
                                       , {from: p1}).should.be.fulfilled;
             // stakeTokens call successful post-initialization
-            await this.creditProtocol.stakeTokens(ucacId2, postCreationStake, {from: p1}).should.be.fulfilled;
-            const a = await this.creditProtocol.ucacs(ucacId2).should.be.fulfilled;
+            await this.creditProtocol.stakeTokens(ucacAddr, postCreationStake, {from: p1}).should.be.fulfilled;
+            const a = await this.creditProtocol.ucacs(ucacAddr).should.be.fulfilled;
             a[1].should.be.bignumber.equal(creationStake.add(postCreationStake));
             // tokens can be unstaked
-            await this.creditProtocol.unstakeTokens(ucacId2, postCreationStake, {from: p1}).should.be.fulfilled;
-            const b = await this.creditProtocol.ucacs(ucacId2).should.be.fulfilled;
+            await this.creditProtocol.unstakeTokens(ucacAddr, postCreationStake, {from: p1}).should.be.fulfilled;
+            const b = await this.creditProtocol.ucacs(ucacAddr).should.be.fulfilled;
             b[1].should.be.bignumber.equal(creationStake);
             const userTokens = await this.cpToken.balanceOf(p1);
             userTokens.should.be.bignumber.equal(mintAmount.sub(creationStake));
@@ -191,7 +189,7 @@ contract('CreditProtocolTest', function([admin, p1, p2, ucacAddr]) {
         beforeEach(async function() {
             await this.cpToken.approve(this.creditProtocol.address, web3.toWei(1), {from: p1}).should.be.fulfilled;
             await this.creditProtocol.createAndStakeUcac( this.basicUCAC.address
-                                               , ucacId1, usd, web3.toWei(1), {from: p1}).should.be.fulfilled;
+                , ucacId1, usd, web3.toWei(1), {from: p1}).should.be.fulfilled;
         });
 
         it("as time passes, txLevel decays as expected", async function() {

--- a/test/CreditProtocol.js
+++ b/test/CreditProtocol.js
@@ -78,7 +78,7 @@ contract('CreditProtocolTest', function([admin, p1, p2]) {
             nonce.should.be.bignumber.equal(0);
             nonce = h.bignumToHexString(nonce);
             let amount = h.bignumToHexString(10);
-            let content = [this.basicUCAC.address, p1, p2, amount, nonce].map(h.stripHex).join("")
+            let content = h.creditHash(this.basicUCAC.address, p1, p2, amount, nonce)
             let sig1 = h.sign(p1, content);
             let sig2 = h.sign(p2, content);
             txReciept = await this.creditProtocol.issueCredit( this.basicUCAC.address, p1, p2, amount
@@ -101,7 +101,7 @@ contract('CreditProtocolTest', function([admin, p1, p2]) {
             nonce = p1 < p2 ? await this.creditProtocol.nonces(p1, p2) : await this.creditProtocol.nonces(p2, p1);
             nonce.should.be.bignumber.equal(1);
             nonce = h.bignumToHexString(nonce);
-            content = [this.basicUCAC.address, p1, p2, amount, nonce].map(h.stripHex).join("")
+            content = h.creditHash(this.basicUCAC.address, p1, p2, amount, nonce);
             sig1 = h.sign(p1, content);
             sig2 = h.sign(p2, content);
             txReciept = await this.creditProtocol.issueCredit( this.basicUCAC.address, p1, p2, amount
@@ -117,7 +117,7 @@ contract('CreditProtocolTest', function([admin, p1, p2]) {
             nonce = p1 < p2 ? await this.creditProtocol.nonces(p1, p2) : await this.creditProtocol.nonces(p2, p1);
             nonce.should.be.bignumber.equal(2);
             nonce = h.bignumToHexString(nonce);
-            content = [this.basicUCAC.address, p1, p2, amount, nonce].map(h.stripHex).join("")
+            content = h.creditHash(this.basicUCAC.address, p1, p2, amount, nonce);
             sig1 = h.sign(p1, content);
             sig2 = h.sign(p2, content);
             // tx per hour = 2, so a 3rd should fail
@@ -144,7 +144,7 @@ contract('CreditProtocolTest', function([admin, p1, p2]) {
             let nonce = p1 < p2 ? await this.creditProtocol.nonces(p1, p2) : await this.creditProtocol.nonces(p2, p1);
             nonce = h.bignumToHexString(nonce);
             let amount = h.bignumToHexString(10);
-            let content = [this.basicUCAC.address, p1, p2, amount, nonce].map(h.stripHex).join("")
+            let content = h.creditHash(this.basicUCAC.address, p1, p2, amount, nonce);
             let sig1 = h.sign(p1, content);
             let sig2 = h.sign(p2, content);
             let txReciept = await this.creditProtocol.issueCredit( this.basicUCAC.address, p1, p2, amount
@@ -181,7 +181,7 @@ contract('CreditProtocolTest', function([admin, p1, p2]) {
             nonce.should.be.bignumber.equal(1);
             nonce = h.bignumToHexString(nonce);
             let amount = h.bignumToHexString(10);
-            let content = [this.basicUCAC.address, p1, p2, amount, nonce].map(h.stripHex).join("")
+            let content = h.creditHash(this.basicUCAC.address, p1, p2, amount, nonce);
             let sig1 = h.sign(p1, content);
             let sig2 = h.sign(p2, content);
             await this.creditProtocol.issueCredit( this.basicUCAC.address, p1, p2, amount
@@ -205,7 +205,7 @@ contract('CreditProtocolTest', function([admin, p1, p2]) {
             let nonce = p1 < p2 ? await this.creditProtocol.nonces(p1, p2) : await this.creditProtocol.nonces(p2, p1);
             nonce.should.be.bignumber.equal(2);
             nonce = h.bignumToHexString(nonce);
-            let content = [this.basicUCAC.address, p1, p2, amount, nonce].map(h.stripHex).join("")
+            let content = h.creditHash(this.basicUCAC.address, p1, p2, amount, nonce);
             let sig1 = h.sign(p1, content);
             let sig2 = h.sign(p2, content);
             let txReciept = await this.creditProtocol.issueCredit( this.basicUCAC.address, p1, p2, amount
@@ -221,7 +221,7 @@ contract('CreditProtocolTest', function([admin, p1, p2]) {
             nonce = p1 < p2 ? await this.creditProtocol.nonces(p1, p2) : await this.creditProtocol.nonces(p2, p1);
             nonce.should.be.bignumber.equal(2);
             nonce = h.bignumToHexString(nonce);
-            content = [this.basicUCAC.address, p1, p2, amount, nonce].map(h.stripHex).join("")
+            content = h.creditHash(this.basicUCAC.address, p1, p2, amount, nonce);
             sig1 = h.sign(p1, content);
             sig2 = h.sign(p2, content);
             txReciept = await this.creditProtocol.issueCredit( this.basicUCAC.address, p1, p2, amount

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -116,7 +116,7 @@ async function makeTransaction(cp, ucacAddr, creditor, debtor, _amount) {
     let nonce = creditor < debtor ? await cp.nonces(creditor, debtor) : await cp.nonces(debtor, creditor);
     nonce = bignumToHexString(nonce);
     let amount = bignumToHexString(_amount);
-    let content = [ucacAddr, creditor, debtor, amount, nonce].map(stripHex).join("")
+    let content = creditHash(ucacAddr, creditor, debtor, amount, nonce);
     let sig1 = sign(creditor, content);
     let sig2 = sign(debtor, content);
     let txReciept = await cp.issueCredit( ucacAddr, creditor, debtor, amount
@@ -126,3 +126,8 @@ async function makeTransaction(cp, ucacAddr, creditor, debtor, _amount) {
     return txReciept;
 }
 exports.makeTransaction = makeTransaction;
+
+function creditHash(ucacAddr, p1, p2, amount, nonce) {
+    return [ucacAddr, p1, p2, amount, nonce].map(stripHex).join("")
+}
+exports.creditHash = creditHash;

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -1,5 +1,7 @@
 exports.EVMThrow = 'invalid opcode';
 
+const testMemo = web3.fromAscii("test1")
+
 exports.b2s = function(bytes) {
     var s = "";
     for(var i=2; i<bytes.length; i+=2) {
@@ -76,3 +78,51 @@ const latestTime = function() {
     return web3.eth.getBlock('latest').timestamp;
 };
 exports.latestTime = latestTime;
+
+function sign(signer, content) {
+    let contentHash = web3.sha3(content, {encoding: 'hex'});
+    let sig = web3.eth.sign(signer, contentHash, {encoding: 'hex'});
+    sig = sig.substr(2, sig.length);
+
+    let res = {};
+    res.r = "0x" + sig.substr(0, 64);
+    res.s = "0x" + sig.substr(64, 64);
+    res.v = web3.toDecimal("0x" + sig.substr(128, 2));
+    if (res.v < 27) res.v += 27;
+    res.v = bignumToHexString(web3.toBigNumber(res.v));
+
+    return res;
+}
+exports.sign = sign;
+
+function bignumToHexString(num) {
+    const a = num.toString(16);
+    return "0x" + '0'.repeat(64 - a.length) + a;
+}
+exports.bignumToHexString = bignumToHexString;
+
+function fillBytes32(ascii) {
+    // 66 instead of 64 to account for the '0x' prefix
+    return ascii + '0'.repeat(66 - ascii.length);
+}
+exports.fillBytes32 = fillBytes32;
+
+function stripHex(addr) {
+    return addr.substr(2, addr.length);
+}
+exports.stripHex = stripHex;
+
+async function makeTransaction(cp, ucacAddr, creditor, debtor, _amount) {
+    let nonce = creditor < debtor ? await cp.nonces(creditor, debtor) : await cp.nonces(debtor, creditor);
+    nonce = bignumToHexString(nonce);
+    let amount = bignumToHexString(_amount);
+    let content = [ucacAddr, creditor, debtor, amount, nonce].map(stripHex).join("")
+    let sig1 = sign(creditor, content);
+    let sig2 = sign(debtor, content);
+    let txReciept = await cp.issueCredit( ucacAddr, creditor, debtor, amount
+                                   , [ sig1.r, sig1.s, sig1.v ]
+                                   , [ sig2.r, sig2.s, sig2.v ]
+                                   , testMemo, {from: creditor});
+    return txReciept;
+}
+exports.makeTransaction = makeTransaction;


### PR DESCRIPTION
- adding nonces to `IssueCredit` event
- removing `bytes32 ucacId` entirely, relying on `ucacAddr` as unique identifier
- updating tests to deal with above changes
- cleaning up `helpers.js`