### PR TITLE
🔒 Fix DoS vulnerability in Credit Protocol contract

### DIFF
--- a/contracts/CreditProtocol.sol
+++ b/contracts/CreditProtocol.sol
@@ -105,7 +105,7 @@ contract CreditProtocol is Ownable {
         return adjustedTxLevel;
     }
 
-    function executeUcacTx(address _ucacContractAddr) public {
+    function executeUcacTx(address _ucacContractAddr) private {
         uint256 txLevelBeforeCurrentTx = currentTxLevel(_ucacContractAddr);
         uint256 txLevelAfterCurrentTx = txLevelBeforeCurrentTx + 10 ** 27 / txPerGigaTokenPerHour;
         require(ucacs[_ucacContractAddr].totalStakedTokens >= txLevelAfterCurrentTx);


### PR DESCRIPTION
`#executeUcacTx` is an inexpensive and unauthenticated function that increases the transaction counter for a UCAC without actually performing a transaction, up to that UCAC's transaction limit.

A motivated attacker can call this function continuously to perform a denial-of-service (DoS) attack on a UCAC, preventing legitimate transactions using that UCAC from being processed.

Once started, this attack can be maintained indefinitely.

Potential mitigations/effects on a live contract include:

 * An attack on a UCAC may incentivize its stakeholders to unstake their tokens.

 * The fewer tokens staked in a UCAC, the less expensive the attack becomes to perform and maintain.

 * Staking more tokens in the UCAC will increase the transaction limit, thus increasing the cost to perform and maintain the attack.

The best mitigation for this attack, then, for a live contract, would be for token holders to stake enough tokens in the affected UCAC to make the attack too expensive for the attacker to maintain.

This PR mitigates the vulnerability by reducing the visibility of the `#executeUcacTx` function to `private`, allowing it to only be called by other functions within the contract.